### PR TITLE
Add FastAPI backend for law firm site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+law_firm.db
+.env
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Deniz Hukuk Bürosu Backend
+
+Bu depo, Deniz Hukuk Bürosu için geliştirilen FastAPI tabanlı bir arka uç uygulamasını içerir. API; avukat profilleri, uzmanlık alanları, dava sonuçları, müşteri geri bildirimleri ve iletişim mesajlarını yönetmek için uç noktalar sağlar.
+
+## Özellikler
+
+- Uzmanlık alanlarını listeleme ve yönetme
+- Avukat profillerini oluşturma, güncelleme ve silme
+- Başarı hikayeleri (dava sonuçları) kaydı
+- Müşteri geri bildirimleri (referanslar) toplama
+- İletişim formu mesajlarını kaydetme
+- CORS yapılandırması sayesinde farklı ön yüzler tarafından kullanılabilir
+
+## Kurulum
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Geliştirme Sunucusunu Başlatma
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Sunucu varsayılan olarak `http://127.0.0.1:8000` adresinde çalışır. Etkileşimli API dokümantasyonuna `http://127.0.0.1:8000/docs` üzerinden erişebilirsiniz.
+
+## Çevresel Değişkenler
+
+- `DATABASE_URL`: Varsayılan olarak `sqlite:///./law_firm.db` kullanılır. İsteğe bağlı olarak PostgreSQL gibi farklı bir veritabanı URI'si tanımlanabilir.
+
+## Test Verisi Oluşturma
+
+Hızlıca denemek için `app/database.py` içerisindeki `session_scope` yardımcı fonksiyonu kullanılabilir:
+
+```python
+from app.database import session_scope
+from app import models
+
+with session_scope() as session:
+    family_law = models.PracticeArea(name="Aile Hukuku", description="Boşanma, velayet ve miras.")
+    session.add(family_law)
+```
+
+Bu arka uç üzerine inşa edeceğiniz ön yüz uygulaması, uç noktaları kullanarak içerik yönetimi yapabilir.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,8 @@
+"""Backend package for the law firm website."""
+
+__all__ = [
+    "database",
+    "models",
+    "schemas",
+    "crud",
+]

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,232 @@
+"""Database interaction helpers for the law firm backend."""
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from . import models, schemas
+
+
+# Practice areas -----------------------------------------------------------------
+
+def list_practice_areas(db: Session) -> List[models.PracticeArea]:
+    return db.execute(select(models.PracticeArea).order_by(models.PracticeArea.name)).scalars().all()
+
+
+def get_practice_area(db: Session, practice_area_id: int) -> Optional[models.PracticeArea]:
+    return db.get(models.PracticeArea, practice_area_id)
+
+
+def create_practice_area(db: Session, data: schemas.PracticeAreaCreate) -> models.PracticeArea:
+    practice_area = models.PracticeArea(**data.dict())
+    db.add(practice_area)
+    db.flush()
+    return practice_area
+
+
+def update_practice_area(
+    db: Session, instance: models.PracticeArea, data: schemas.PracticeAreaUpdate
+) -> models.PracticeArea:
+    update_data = data.dict(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(instance, key, value)
+    db.add(instance)
+    db.flush()
+    return instance
+
+
+def delete_practice_area(db: Session, instance: models.PracticeArea) -> None:
+    db.delete(instance)
+    db.flush()
+
+
+# Lawyer helpers ------------------------------------------------------------------
+
+def list_lawyers(
+    db: Session,
+    *,
+    practice_area_id: Optional[int] = None,
+    search: Optional[str] = None,
+) -> Sequence[models.Lawyer]:
+    stmt = select(models.Lawyer).options(selectinload(models.Lawyer.practice_areas))
+
+    if practice_area_id is not None:
+        stmt = stmt.join(models.Lawyer.practice_areas).where(models.PracticeArea.id == practice_area_id)
+    if search:
+        search_term = f"%{search.lower()}%"
+        stmt = stmt.where(models.Lawyer.full_name.ilike(search_term) | models.Lawyer.bio.ilike(search_term))
+
+    stmt = stmt.order_by(models.Lawyer.full_name)
+    return db.execute(stmt).scalars().unique().all()
+
+
+def get_lawyer(db: Session, lawyer_id: int) -> Optional[models.Lawyer]:
+    stmt = (
+        select(models.Lawyer)
+        .options(
+            selectinload(models.Lawyer.practice_areas),
+            selectinload(models.Lawyer.case_results),
+            selectinload(models.Lawyer.testimonials),
+        )
+        .where(models.Lawyer.id == lawyer_id)
+    )
+    return db.execute(stmt).scalar_one_or_none()
+
+
+def _attach_practice_areas(
+    db: Session, lawyer: models.Lawyer, practice_area_ids: Optional[List[int]]
+) -> None:
+    if practice_area_ids is None:
+        return
+    if not practice_area_ids:
+        lawyer.practice_areas.clear()
+        return
+
+    areas = (
+        db.execute(
+            select(models.PracticeArea).where(models.PracticeArea.id.in_(practice_area_ids))
+        )
+        .scalars()
+        .all()
+    )
+    lawyer.practice_areas = areas
+
+
+def create_lawyer(db: Session, data: schemas.LawyerCreate) -> models.Lawyer:
+    lawyer = models.Lawyer(
+        full_name=data.full_name,
+        title=data.title,
+        bio=data.bio,
+        email=data.email,
+        phone=data.phone,
+        experience_years=data.experience_years,
+        photo_url=data.photo_url,
+    )
+    lawyer.languages = data.languages
+    _attach_practice_areas(db, lawyer, data.practice_area_ids)
+    db.add(lawyer)
+    db.flush()
+    return lawyer
+
+
+def update_lawyer(db: Session, instance: models.Lawyer, data: schemas.LawyerUpdate) -> models.Lawyer:
+    update_data = data.dict(exclude_unset=True)
+    languages = update_data.pop("languages", None)
+    practice_area_ids = update_data.pop("practice_area_ids", None)
+
+    for key, value in update_data.items():
+        setattr(instance, key, value)
+
+    if languages is not None:
+        instance.languages = languages
+    if practice_area_ids is not None:
+        _attach_practice_areas(db, instance, practice_area_ids)
+
+    db.add(instance)
+    db.flush()
+    return instance
+
+
+def delete_lawyer(db: Session, instance: models.Lawyer) -> None:
+    db.delete(instance)
+    db.flush()
+
+
+# Case results --------------------------------------------------------------------
+
+def list_case_results(db: Session) -> Sequence[models.CaseResult]:
+    stmt = (
+        select(models.CaseResult)
+        .options(selectinload(models.CaseResult.lawyer), selectinload(models.CaseResult.practice_area))
+        .order_by(models.CaseResult.resolved_on.desc().nullslast(), models.CaseResult.title)
+    )
+    return db.execute(stmt).scalars().all()
+
+
+def get_case_result(db: Session, case_result_id: int) -> Optional[models.CaseResult]:
+    stmt = (
+        select(models.CaseResult)
+        .options(selectinload(models.CaseResult.lawyer), selectinload(models.CaseResult.practice_area))
+        .where(models.CaseResult.id == case_result_id)
+    )
+    return db.execute(stmt).scalar_one_or_none()
+
+
+def create_case_result(db: Session, data: schemas.CaseResultCreate) -> models.CaseResult:
+    case_result = models.CaseResult(**data.dict())
+    db.add(case_result)
+    db.flush()
+    return case_result
+
+
+def update_case_result(
+    db: Session, instance: models.CaseResult, data: schemas.CaseResultUpdate
+) -> models.CaseResult:
+    update_data = data.dict(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(instance, key, value)
+    db.add(instance)
+    db.flush()
+    return instance
+
+
+def delete_case_result(db: Session, instance: models.CaseResult) -> None:
+    db.delete(instance)
+    db.flush()
+
+
+# Testimonials --------------------------------------------------------------------
+
+def list_testimonials(db: Session) -> Sequence[models.Testimonial]:
+    stmt = select(models.Testimonial).options(selectinload(models.Testimonial.lawyer)).order_by(
+        models.Testimonial.id.desc()
+    )
+    return db.execute(stmt).scalars().all()
+
+
+def get_testimonial(db: Session, testimonial_id: int) -> Optional[models.Testimonial]:
+    stmt = (
+        select(models.Testimonial)
+        .options(selectinload(models.Testimonial.lawyer))
+        .where(models.Testimonial.id == testimonial_id)
+    )
+    return db.execute(stmt).scalar_one_or_none()
+
+
+def create_testimonial(db: Session, data: schemas.TestimonialCreate) -> models.Testimonial:
+    testimonial = models.Testimonial(**data.dict())
+    db.add(testimonial)
+    db.flush()
+    return testimonial
+
+
+def update_testimonial(
+    db: Session, instance: models.Testimonial, data: schemas.TestimonialUpdate
+) -> models.Testimonial:
+    update_data = data.dict(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(instance, key, value)
+    db.add(instance)
+    db.flush()
+    return instance
+
+
+def delete_testimonial(db: Session, instance: models.Testimonial) -> None:
+    db.delete(instance)
+    db.flush()
+
+
+# Contact messages ----------------------------------------------------------------
+
+def list_contact_messages(db: Session) -> Sequence[models.ContactMessage]:
+    stmt = select(models.ContactMessage).order_by(models.ContactMessage.created_at.desc())
+    return db.execute(stmt).scalars().all()
+
+
+def create_contact_message(db: Session, data: schemas.ContactMessageCreate) -> models.ContactMessage:
+    message = models.ContactMessage(**data.dict())
+    db.add(message)
+    db.flush()
+    return message

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,54 @@
+"""Database configuration and utilities for the law firm backend."""
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker, Session
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./law_firm.db")
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def init_db() -> None:
+    """Create database tables if they do not already exist."""
+    from . import models  # noqa: F401 - ensure models are imported for metadata
+
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Provide a transactional scope around a series of operations."""
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+@contextmanager
+def session_scope() -> Generator[Session, None, None]:
+    """Context manager that yields a database session and handles commit/rollback."""
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,277 @@
+"""FastAPI application entry point for the law firm backend."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query, status
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy.orm import Session
+
+from . import crud, schemas
+from .database import get_db, init_db
+
+app = FastAPI(title="Law Firm Backend", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+
+
+@app.get("/", summary="Genel bilgi")
+def root() -> dict[str, str]:
+    return {
+        "message": "Deniz Hukuk Bürosu API'sine hoş geldiniz.",
+        "docs": "/docs",
+    }
+
+
+@app.get("/health", summary="Sağlık durumu")
+def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+# Practice areas ------------------------------------------------------------------
+
+
+@app.get("/practice-areas", response_model=List[schemas.PracticeAreaRead], summary="Uzmanlık alanlarını listele")
+def list_practice_areas(db: Session = Depends(get_db)):
+    return crud.list_practice_areas(db)
+
+
+@app.post(
+    "/practice-areas",
+    response_model=schemas.PracticeAreaRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Yeni uzmanlık alanı oluştur",
+)
+def create_practice_area(data: schemas.PracticeAreaCreate, db: Session = Depends(get_db)):
+    return crud.create_practice_area(db, data)
+
+
+@app.get(
+    "/practice-areas/{practice_area_id}",
+    response_model=schemas.PracticeAreaRead,
+    summary="Uzmanlık alanı detayı",
+)
+def get_practice_area(practice_area_id: int, db: Session = Depends(get_db)):
+    instance = crud.get_practice_area(db, practice_area_id)
+    if not instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Uzmanlık alanı bulunamadı")
+    return instance
+
+
+@app.put(
+    "/practice-areas/{practice_area_id}",
+    response_model=schemas.PracticeAreaRead,
+    summary="Uzmanlık alanını güncelle",
+)
+def update_practice_area(
+    practice_area_id: int, data: schemas.PracticeAreaUpdate, db: Session = Depends(get_db)
+):
+    instance = crud.get_practice_area(db, practice_area_id)
+    if not instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Uzmanlık alanı bulunamadı")
+    return crud.update_practice_area(db, instance, data)
+
+
+@app.delete(
+    "/practice-areas/{practice_area_id}", status_code=status.HTTP_204_NO_CONTENT, summary="Uzmanlık alanını sil"
+)
+def delete_practice_area(practice_area_id: int, db: Session = Depends(get_db)):
+    instance = crud.get_practice_area(db, practice_area_id)
+    if not instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Uzmanlık alanı bulunamadı")
+    crud.delete_practice_area(db, instance)
+    return None
+
+
+# Lawyers -------------------------------------------------------------------------
+
+
+@app.get(
+    "/lawyers",
+    response_model=List[schemas.LawyerRead],
+    summary="Avukatları listele",
+)
+def list_lawyers(
+    practice_area_id: Optional[int] = Query(None, alias="practiceAreaId"),
+    search: Optional[str] = Query(None, description="İsim veya biyografide arama"),
+    db: Session = Depends(get_db),
+):
+    return crud.list_lawyers(db, practice_area_id=practice_area_id, search=search)
+
+
+@app.post("/lawyers", response_model=schemas.LawyerRead, status_code=status.HTTP_201_CREATED)
+def create_lawyer(data: schemas.LawyerCreate, db: Session = Depends(get_db)):
+    return crud.create_lawyer(db, data)
+
+
+@app.get("/lawyers/{lawyer_id}", response_model=schemas.LawyerRead)
+def get_lawyer(lawyer_id: int, db: Session = Depends(get_db)):
+    instance = crud.get_lawyer(db, lawyer_id)
+    if not instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Avukat bulunamadı")
+    return instance
+
+
+@app.put("/lawyers/{lawyer_id}", response_model=schemas.LawyerRead)
+def update_lawyer(lawyer_id: int, data: schemas.LawyerUpdate, db: Session = Depends(get_db)):
+    instance = crud.get_lawyer(db, lawyer_id)
+    if not instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Avukat bulunamadı")
+    return crud.update_lawyer(db, instance, data)
+
+
+@app.delete("/lawyers/{lawyer_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_lawyer(lawyer_id: int, db: Session = Depends(get_db)):
+    instance = crud.get_lawyer(db, lawyer_id)
+    if not instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Avukat bulunamadı")
+    crud.delete_lawyer(db, instance)
+    return None
+
+
+# Case results --------------------------------------------------------------------
+
+
+@app.get("/case-results", response_model=List[schemas.CaseResultRead])
+def list_case_results(db: Session = Depends(get_db)):
+    results = crud.list_case_results(db)
+    return [
+        schemas.CaseResultRead.from_orm(result).copy(
+            update={
+                "lawyer_name": result.lawyer.full_name if result.lawyer else None,
+                "practice_area_name": result.practice_area.name if result.practice_area else None,
+            }
+        )
+        for result in results
+    ]
+
+
+@app.post("/case-results", response_model=schemas.CaseResultRead, status_code=status.HTTP_201_CREATED)
+def create_case_result(data: schemas.CaseResultCreate, db: Session = Depends(get_db)):
+    result = crud.create_case_result(db, data)
+    db.refresh(result)
+    return schemas.CaseResultRead.from_orm(result).copy(
+        update={
+            "lawyer_name": result.lawyer.full_name if result.lawyer else None,
+            "practice_area_name": result.practice_area.name if result.practice_area else None,
+        }
+    )
+
+
+@app.get("/case-results/{case_result_id}", response_model=schemas.CaseResultRead)
+def get_case_result(case_result_id: int, db: Session = Depends(get_db)):
+    result = crud.get_case_result(db, case_result_id)
+    if not result:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Başarı hikayesi bulunamadı")
+    return schemas.CaseResultRead.from_orm(result).copy(
+        update={
+            "lawyer_name": result.lawyer.full_name if result.lawyer else None,
+            "practice_area_name": result.practice_area.name if result.practice_area else None,
+        }
+    )
+
+
+@app.put("/case-results/{case_result_id}", response_model=schemas.CaseResultRead)
+def update_case_result(case_result_id: int, data: schemas.CaseResultUpdate, db: Session = Depends(get_db)):
+    instance = crud.get_case_result(db, case_result_id)
+    if not instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Başarı hikayesi bulunamadı")
+    result = crud.update_case_result(db, instance, data)
+    db.refresh(result)
+    return schemas.CaseResultRead.from_orm(result).copy(
+        update={
+            "lawyer_name": result.lawyer.full_name if result.lawyer else None,
+            "practice_area_name": result.practice_area.name if result.practice_area else None,
+        }
+    )
+
+
+@app.delete("/case-results/{case_result_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_case_result(case_result_id: int, db: Session = Depends(get_db)):
+    instance = crud.get_case_result(db, case_result_id)
+    if not instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Başarı hikayesi bulunamadı")
+    crud.delete_case_result(db, instance)
+    return None
+
+
+# Testimonials --------------------------------------------------------------------
+
+
+@app.get("/testimonials", response_model=List[schemas.TestimonialRead])
+def list_testimonials(db: Session = Depends(get_db)):
+    testimonials = crud.list_testimonials(db)
+    return [
+        schemas.TestimonialRead.from_orm(item).copy(update={"lawyer_name": item.lawyer.full_name})
+        for item in testimonials
+    ]
+
+
+@app.post("/testimonials", response_model=schemas.TestimonialRead, status_code=status.HTTP_201_CREATED)
+def create_testimonial(data: schemas.TestimonialCreate, db: Session = Depends(get_db)):
+    testimonial = crud.create_testimonial(db, data)
+    db.refresh(testimonial)
+    return schemas.TestimonialRead.from_orm(testimonial).copy(
+        update={"lawyer_name": testimonial.lawyer.full_name if testimonial.lawyer else None}
+    )
+
+
+@app.get("/testimonials/{testimonial_id}", response_model=schemas.TestimonialRead)
+def get_testimonial(testimonial_id: int, db: Session = Depends(get_db)):
+    testimonial = crud.get_testimonial(db, testimonial_id)
+    if not testimonial:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Geri bildirim bulunamadı")
+    return schemas.TestimonialRead.from_orm(testimonial).copy(
+        update={"lawyer_name": testimonial.lawyer.full_name if testimonial.lawyer else None}
+    )
+
+
+@app.put("/testimonials/{testimonial_id}", response_model=schemas.TestimonialRead)
+def update_testimonial(testimonial_id: int, data: schemas.TestimonialUpdate, db: Session = Depends(get_db)):
+    instance = crud.get_testimonial(db, testimonial_id)
+    if not instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Geri bildirim bulunamadı")
+    testimonial = crud.update_testimonial(db, instance, data)
+    db.refresh(testimonial)
+    return schemas.TestimonialRead.from_orm(testimonial).copy(
+        update={"lawyer_name": testimonial.lawyer.full_name if testimonial.lawyer else None}
+    )
+
+
+@app.delete("/testimonials/{testimonial_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_testimonial(testimonial_id: int, db: Session = Depends(get_db)):
+    instance = crud.get_testimonial(db, testimonial_id)
+    if not instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Geri bildirim bulunamadı")
+    crud.delete_testimonial(db, instance)
+    return None
+
+
+# Contact messages ----------------------------------------------------------------
+
+
+@app.get("/contact-messages", response_model=List[schemas.ContactMessageRead])
+def list_contact_messages(db: Session = Depends(get_db)):
+    return crud.list_contact_messages(db)
+
+
+@app.post(
+    "/contact-messages",
+    response_model=schemas.ContactMessageRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_contact_message(data: schemas.ContactMessageCreate, db: Session = Depends(get_db)):
+    message = crud.create_contact_message(db, data)
+    db.refresh(message)
+    return message

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,139 @@
+"""SQLAlchemy models for the law firm backend."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+    Text,
+)
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+lawyer_practice_area = Table(
+    "lawyer_practice_area",
+    Base.metadata,
+    Column("lawyer_id", ForeignKey("lawyers.id"), primary_key=True),
+    Column("practice_area_id", ForeignKey("practice_areas.id"), primary_key=True),
+)
+
+
+class Lawyer(Base):
+    __tablename__ = "lawyers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    full_name = Column(String(255), nullable=False)
+    title = Column(String(255), nullable=True)
+    bio = Column(Text, nullable=True)
+    email = Column(String(255), nullable=True, unique=True)
+    phone = Column(String(50), nullable=True)
+    experience_years = Column(Integer, nullable=True)
+    photo_url = Column(String(512), nullable=True)
+    _languages = Column("languages", Text, default="[]", nullable=False)
+
+    practice_areas = relationship(
+        "PracticeArea",
+        secondary=lawyer_practice_area,
+        back_populates="lawyers",
+        lazy="selectin",
+    )
+    case_results = relationship(
+        "CaseResult", back_populates="lawyer", cascade="all, delete-orphan", lazy="selectin"
+    )
+    testimonials = relationship(
+        "Testimonial", back_populates="lawyer", cascade="all, delete-orphan", lazy="selectin"
+    )
+
+    @property
+    def languages(self) -> List[str]:
+        try:
+            return json.loads(self._languages)
+        except json.JSONDecodeError:
+            return []
+
+    @languages.setter
+    def languages(self, value: List[str]) -> None:
+        self._languages = json.dumps(value or [])
+
+    def __repr__(self) -> str:  # pragma: no cover - repr for debugging only
+        return f"<Lawyer id={self.id} name={self.full_name!r}>"
+
+
+class PracticeArea(Base):
+    __tablename__ = "practice_areas"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False, unique=True)
+    description = Column(Text, nullable=True)
+
+    lawyers = relationship(
+        "Lawyer",
+        secondary=lawyer_practice_area,
+        back_populates="practice_areas",
+        lazy="selectin",
+    )
+    case_results = relationship(
+        "CaseResult", back_populates="practice_area", cascade="all, delete-orphan", lazy="selectin"
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - repr for debugging only
+        return f"<PracticeArea id={self.id} name={self.name!r}>"
+
+
+class CaseResult(Base):
+    __tablename__ = "case_results"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(255), nullable=False)
+    summary = Column(Text, nullable=True)
+    outcome = Column(Text, nullable=True)
+    resolved_on = Column(Date, nullable=True)
+
+    lawyer_id = Column(Integer, ForeignKey("lawyers.id"), nullable=False)
+    practice_area_id = Column(Integer, ForeignKey("practice_areas.id"), nullable=True)
+
+    lawyer = relationship("Lawyer", back_populates="case_results")
+    practice_area = relationship("PracticeArea", back_populates="case_results")
+
+    def __repr__(self) -> str:  # pragma: no cover - repr for debugging only
+        return f"<CaseResult id={self.id} title={self.title!r}>"
+
+
+class Testimonial(Base):
+    __tablename__ = "testimonials"
+
+    id = Column(Integer, primary_key=True, index=True)
+    client_name = Column(String(255), nullable=False)
+    content = Column(Text, nullable=False)
+    rating = Column(Integer, nullable=True)
+
+    lawyer_id = Column(Integer, ForeignKey("lawyers.id"), nullable=False)
+
+    lawyer = relationship("Lawyer", back_populates="testimonials")
+
+    def __repr__(self) -> str:  # pragma: no cover - repr for debugging only
+        return f"<Testimonial id={self.id} client={self.client_name!r}>"
+
+
+class ContactMessage(Base):
+    __tablename__ = "contact_messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    full_name = Column(String(255), nullable=False)
+    email = Column(String(255), nullable=False)
+    phone = Column(String(50), nullable=True)
+    preferred_contact_method = Column(String(50), nullable=True)
+    message = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    def __repr__(self) -> str:  # pragma: no cover - repr for debugging only
+        return f"<ContactMessage id={self.id} email={self.email!r}>"

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,169 @@
+"""Pydantic schemas for request and response models."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, EmailStr, Field, validator
+
+
+class PracticeAreaBase(BaseModel):
+    name: str = Field(..., max_length=255)
+    description: Optional[str] = None
+
+
+class PracticeAreaCreate(PracticeAreaBase):
+    pass
+
+
+class PracticeAreaUpdate(BaseModel):
+    name: Optional[str] = Field(None, max_length=255)
+    description: Optional[str] = None
+
+
+class PracticeAreaRead(PracticeAreaBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class LawyerBase(BaseModel):
+    full_name: str = Field(..., max_length=255)
+    title: Optional[str] = Field(None, max_length=255)
+    bio: Optional[str] = None
+    email: Optional[EmailStr] = None
+    phone: Optional[str] = Field(None, max_length=50)
+    experience_years: Optional[int] = Field(None, ge=0)
+    photo_url: Optional[str] = Field(None, max_length=512)
+    languages: List[str] = []
+    practice_area_ids: List[int] = []
+
+    @validator("languages", pre=True)
+    def validate_languages(cls, value):  # type: ignore[override]
+        if isinstance(value, str):
+            return [value]
+        return value
+
+
+class LawyerCreate(LawyerBase):
+    pass
+
+
+class LawyerUpdate(BaseModel):
+    full_name: Optional[str] = Field(None, max_length=255)
+    title: Optional[str] = Field(None, max_length=255)
+    bio: Optional[str] = None
+    email: Optional[EmailStr] = None
+    phone: Optional[str] = Field(None, max_length=50)
+    experience_years: Optional[int] = Field(None, ge=0)
+    photo_url: Optional[str] = Field(None, max_length=512)
+    languages: Optional[List[str]] = None
+    practice_area_ids: Optional[List[int]] = None
+
+    @validator("languages", pre=True)
+    def validate_languages(cls, value):  # type: ignore[override]
+        if value is None:
+            return value
+        if isinstance(value, str):
+            return [value]
+        return value
+
+
+class LawyerRead(BaseModel):
+    id: int
+    full_name: str
+    title: Optional[str]
+    bio: Optional[str]
+    email: Optional[EmailStr]
+    phone: Optional[str]
+    experience_years: Optional[int]
+    photo_url: Optional[str]
+    languages: List[str] = []
+    practice_areas: List[PracticeAreaRead] = []
+
+    class Config:
+        orm_mode = True
+
+
+class CaseResultBase(BaseModel):
+    title: str = Field(..., max_length=255)
+    summary: Optional[str] = None
+    outcome: Optional[str] = None
+    resolved_on: Optional[date] = None
+    lawyer_id: int
+    practice_area_id: Optional[int] = None
+
+
+class CaseResultCreate(CaseResultBase):
+    pass
+
+
+class CaseResultUpdate(BaseModel):
+    title: Optional[str] = Field(None, max_length=255)
+    summary: Optional[str] = None
+    outcome: Optional[str] = None
+    resolved_on: Optional[date] = None
+    lawyer_id: Optional[int] = None
+    practice_area_id: Optional[int] = None
+
+
+class CaseResultRead(BaseModel):
+    id: int
+    title: str
+    summary: Optional[str]
+    outcome: Optional[str]
+    resolved_on: Optional[date]
+    lawyer_id: int
+    practice_area_id: Optional[int]
+    lawyer_name: Optional[str] = None
+    practice_area_name: Optional[str] = None
+
+    class Config:
+        orm_mode = True
+
+
+class TestimonialBase(BaseModel):
+    client_name: str = Field(..., max_length=255)
+    content: str
+    rating: Optional[int] = Field(None, ge=1, le=5)
+    lawyer_id: int
+
+
+class TestimonialCreate(TestimonialBase):
+    pass
+
+
+class TestimonialUpdate(BaseModel):
+    client_name: Optional[str] = Field(None, max_length=255)
+    content: Optional[str] = None
+    rating: Optional[int] = Field(None, ge=1, le=5)
+    lawyer_id: Optional[int] = None
+
+
+class TestimonialRead(BaseModel):
+    id: int
+    client_name: str
+    content: str
+    rating: Optional[int]
+    lawyer_id: int
+    lawyer_name: Optional[str] = None
+
+    class Config:
+        orm_mode = True
+
+
+class ContactMessageCreate(BaseModel):
+    full_name: str = Field(..., max_length=255)
+    email: EmailStr
+    phone: Optional[str] = Field(None, max_length=50)
+    preferred_contact_method: Optional[str] = Field(None, max_length=50)
+    message: str
+
+
+class ContactMessageRead(ContactMessageCreate):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+SQLAlchemy==2.0.25
+pydantic==1.10.14
+python-multipart==0.0.9


### PR DESCRIPTION
## Summary
- introduce a FastAPI-based backend with SQLite configuration, CRUD helpers, and Pydantic schemas for lawyers, practice areas, case results, testimonials, and contact messages
- expose REST endpoints for managing site content and include CORS support and healthcheck routes
- document project setup requirements and ignore generated artifacts

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e57845aee48330a245d40892471364